### PR TITLE
Added role arn to Glue Job

### DIFF
--- a/environment/cdk_workshop/app.py
+++ b/environment/cdk_workshop/app.py
@@ -137,7 +137,7 @@ class GlueJobResource(cdk.Stack):
             self,
             "datalakeInput",
             name = "stream-etl-process",
-            role = self.etl_role,
+            role = self.etl_role.role_arn,
             command = aws_glue.CfnJob.JobCommandProperty(
                 name = "gluestreaming",
                 script_location = "s3://{bucket}/{key}".format(


### PR DESCRIPTION
The function expects a role Arn as stated here: https://docs.aws.amazon.com/cdk/api/v1/python/aws_cdk.aws_glue/CfnJob.html Not an iam object.